### PR TITLE
Fix: Incorrect index for testresult2

### DIFF
--- a/src/models/notifyRecipient/notification.ts
+++ b/src/models/notifyRecipient/notification.ts
@@ -118,7 +118,7 @@ export const getSpmTemplateInput = (
               ? "COVID-19 SEROLOGY TEST RESULT"
               : testData[0].testType,
           testdatetime: testData[0].swabCollectionDate,
-          testresult2: testData[0].testResult,
+          testresult2: testData[1].testResult,
           testtype2:
             testData[1].testType === "REAL TIME RT-PCR SWAB"
               ? "COVID-19 PCR TEST RESULT"


### PR DESCRIPTION
`testresult2` should reference index [1] instead of [0]